### PR TITLE
Use SidebarBeforeOutput hook rather than SkinBuildSidebar

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -80,7 +80,7 @@
 	},
 	"Hooks": {
 		"GetPreferences": "ShareHooks::onGetPreferences",
-		"SkinBuildSidebar": "ShareHooks::onSkinBuildSidebar"
+		"SidebarBeforeOutput": "ShareHooks::onSidebarBeforeOutput"
 	},
 	"MessagesDirs": {
 		"Share": [

--- a/includes/Share.php
+++ b/includes/Share.php
@@ -3,7 +3,7 @@
 use MediaWiki\MediaWikiServices;
 
 class ShareHooks {
-	public static function onSkinBuildSidebar( Skin $skin, &$bar ) {
+	public static function onSidebarBeforeOutput( Skin $skin, &$sidebar ) {
 		global $wgExtensionAssetsPath, $wgShareFacebook, $wgShareTwitter,
 			$wgShareLinkedIn, $wgShareTumblr, $wgShareReddit,
 			$wgShareEmail, $wgShareUseBasicButtons,
@@ -31,25 +31,25 @@ class ShareHooks {
 				// 'Full' Mode - Displays buttons straight from each platform's social plugin library
 				if ( !$wgShareUseBasicButtons && !$wgShareUsePlainLinks ) {
 					if ( $wgShareFacebook ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2F' . urlencode( $currenturl ) . '&layout=button&size=small&width=67&height=20&appId" width="67" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>',
 						];
 					}
 
 					if ( $wgShareTwitter ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<a href="https://twitter.com/share" class="twitter-share-button" rel="nofollow" data-dnt="true" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
 						];
 					}
 
 					if ( $wgShareLinkedIn ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script> <script type="IN/Share" data-url="https://www.linkedin.com"></script>',
 						];
 					}
 
 					if ( $wgShareTumblr ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<a class="tumblr-share-button" href="https://www.tumblr.com/share"></a><script id="tumblr-js" async src="https://assets.tumblr.com/share-button.js"></script>',
 						];
 					}
@@ -58,37 +58,37 @@ class ShareHooks {
 				// 'Sidebar images' mode - Doesn't load the button from each platform's social plugin library but instead displays images saying "Share"
 				if ( $wgShareUseBasicButtons && !$wgShareUsePlainLinks ) {
 					if ( $wgShareEmail ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<a href="mailto:%20?body=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/email.png" alt="'.$skin->msg( 'share-email' ).'" width="90" height="30"></a>',
 						];
 					}
 
 					if ( $wgShareFacebook ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<a href="https://www.facebook.com/sharer/sharer.php?u=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/facebook.png" alt="'.$skin->msg( 'share-facebook' ).'" width="90" height="30"></a>',
 						];
 					}
 
 					if ( $wgShareLinkedIn ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<a href="https://www.linkedin.com/sharing/share-offsite/?url=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/linkedin.png" alt="'.$skin->msg( 'share-linkedin' ).'" width="90" height="30"></a>',
 						];
 					}
 
 					if ( $wgShareReddit ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<a href="https://www.reddit.com/submit?url=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/reddit.png" alt="'.$skin->msg( 'share-redit' ).'" width="90" height="30"></a>',
 						];
 					}
 
 					if ( $wgShareTumblr ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<a href="https://www.tumblr.com/share/link?url=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/tumblr.png" alt="'.$skin->msg( 'share-tumblr' ).'" width="90" height="30"></a>',
 						];
 					}
 
 					if ( $wgShareTwitter ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'html' => '<a href="https://www.twitter.com/share?url=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/twitter.png" alt="'.$skin->msg( 'share-twitter' ).'" width="90" height="30"></a>',
 						];
 					}
@@ -97,7 +97,7 @@ class ShareHooks {
 				// 'Plain Sidebar Links' mode - Displays all "Share" buttons as plain sidebar links as if they were any other link in the sidebar
 				if ( !$wgShareUseBasicButtons && $wgShareUsePlainLinks ) {
 					if ( $wgShareFacebook ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'text' => $skin->msg( 'share-facebook' ),
 							'href' => 'https://www.facebook.com/sharer/sharer.php?u=' . urlencode( $currenturl ),
 							'title' => $skin->msg( 'share-facebook' ),
@@ -106,7 +106,7 @@ class ShareHooks {
 					}
 
 					if ( $wgShareTwitter ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'text' => $skin->msg( 'share-twitter' ),
 							'href' => 'https://www.twitter.com/share?url=' . urlencode( $currenturl ),
 							'title' => $skin->msg( 'share-twitter' ),
@@ -115,7 +115,7 @@ class ShareHooks {
 					}
 
 					if ( $wgShareEmail ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'text' => $skin->msg( 'share-email' ),
 							'href' => 'mailto:%20?body=' . urlencode( $currenturl ),
 							'title' => $skin->msg( 'share-email' ),
@@ -124,7 +124,7 @@ class ShareHooks {
 					}
 
 					if ( $wgShareLinkedIn ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'text' => $skin->msg( 'share-linkedin' ),
 							'href' => 'https://www.linkedin.com/sharing/share-offsite/?url=' . urlencode( $currenturl ),
 							'title' => $skin->msg( 'share-linkedin' ),
@@ -133,7 +133,7 @@ class ShareHooks {
 					}
 
 					if ( $wgShareReddit ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'text' => $skin->msg( 'share-reddit' ),
 							'href' => 'https://www.reddit.com/submit?url=' . urlencode( $currenturl ),
 							'title' => $skin->msg( 'share-reddit' ),
@@ -142,7 +142,7 @@ class ShareHooks {
 					}
 
 					if ( $wgShareTumblr ) {
-						$bar['share-header'][] = [
+						$sidebar['share-header'][] = [
 							'text' => $skin->msg( 'share-tumblr' ),
 							'href' => 'https://www.tumblr.com/share/link?url=' . urlencode( $currenturl ),
 							'title' => $skin->msg( 'share-tumblr' ),


### PR DESCRIPTION
The SidebarBeforeOutput hook is called after cache, so the output is not cached unlike the SkinBuildSidebar hook, which is cached. This means if using sidebar cache, it won't work right on all pages, and caches it. For dynamic sidebar items it should use the SidebarBeforeOutput hook instead.