### PR TITLE
Configuration: Use MediaWiki's abstraction layer instead of accessing globals directly

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -74,6 +74,9 @@
 			"value": true
 		}
 	},
+	"ConfigRegistry": {
+		"Share": "GlobalVarConfig::newInstance"
+	},
 	"DefaultUserOptions": {
 		"sharesidebar": 0
 	},

--- a/extension.json
+++ b/extension.json
@@ -2,7 +2,8 @@
 	"name": "Share",
 	"version": "1.2",
 	"author": [
-		"[https://meta.miraheze.org/wiki/User:Agent_Isai Agent Isai]"
+		"[https://meta.miraheze.org/wiki/User:Agent_Isai Agent Isai]",
+		"Alex"
 	],
 	"url": "https://github.com/AgentIsai/Share",
 	"descriptionmsg": "share-desc",

--- a/includes/Share.php
+++ b/includes/Share.php
@@ -4,10 +4,18 @@ use MediaWiki\MediaWikiServices;
 
 class ShareHooks {
 	public static function onSidebarBeforeOutput( Skin $skin, &$sidebar ) {
-		global $wgExtensionAssetsPath, $wgShareFacebook, $wgShareTwitter,
-			$wgShareLinkedIn, $wgShareTumblr, $wgShareReddit,
-			$wgShareEmail, $wgShareUseBasicButtons,
-			$wgShareUsePlainLinks;
+		$services = MediaWikiServices::getInstance();
+
+		$config = $services->getConfigFactory()->makeConfig( 'Share' );
+		$extensionAssetsPath = $config->get( 'ExtensionAssetsPath' );
+		$shareFacebook = $config->get( 'ShareFacebook' );
+		$shareTwitter = $config->get( 'ShareTwitter' );
+		$shareLinkedin = $config->get( 'ShareLinkedIn' );
+		$shareTumblr = $config->get( 'ShareTumblr' );
+		$shareReddit = $config->get( 'ShareReddit' );
+		$shareEmail = $config->get( 'ShareEmail' );
+		$shareUseBasicButtons = $config->get( 'ShareUseBasicButtons' );
+		$shareUsePlainLinks = $config->get( 'ShareUsePlainLinks' );
 
 		// Get title
 		$query = $skin->getRequest()->getQueryValues();
@@ -19,7 +27,6 @@ class ShareHooks {
 		$currenturl = $skin->getTitle()->getFullURL( $query, false, PROTO_CANONICAL );
 
 		// Allow us to store preferences on users so that users can enable or disable the sidebar and to check if user has permission to see sidebar links
-		$services = MediaWikiServices::getInstance();
 		$user = $skin->getUser();
 		$permissionManager = $services->getPermissionManager();
 		$userOptionsLookup = $services->getUserOptionsLookup();
@@ -29,26 +36,26 @@ class ShareHooks {
 			// If Share is disabled in the User preferences then don't show (Default is enabled)
 			if ( !$userOptionsLookup->getOption( $user, 'sharesidebar', 0 ) ) {
 				// 'Full' Mode - Displays buttons straight from each platform's social plugin library
-				if ( !$wgShareUseBasicButtons && !$wgShareUsePlainLinks ) {
-					if ( $wgShareFacebook ) {
+				if ( !$shareUseBasicButtons && !$shareUsePlainLinks ) {
+					if ( $shareFacebook ) {
 						$sidebar['share-header'][] = [
 							'html' => '<iframe src="https://www.facebook.com/plugins/share_button.php?href=https%3A%2F%2F' . urlencode( $currenturl ) . '&layout=button&size=small&width=67&height=20&appId" width="67" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>',
 						];
 					}
 
-					if ( $wgShareTwitter ) {
+					if ( $shareTwitter ) {
 						$sidebar['share-header'][] = [
 							'html' => '<a href="https://twitter.com/share" class="twitter-share-button" rel="nofollow" data-dnt="true" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>',
 						];
 					}
 
-					if ( $wgShareLinkedIn ) {
+					if ( $shareLinkedIn ) {
 						$sidebar['share-header'][] = [
 							'html' => '<script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script> <script type="IN/Share" data-url="https://www.linkedin.com"></script>',
 						];
 					}
 
-					if ( $wgShareTumblr ) {
+					if ( $shareTumblr ) {
 						$sidebar['share-header'][] = [
 							'html' => '<a class="tumblr-share-button" href="https://www.tumblr.com/share"></a><script id="tumblr-js" async src="https://assets.tumblr.com/share-button.js"></script>',
 						];
@@ -56,47 +63,47 @@ class ShareHooks {
 				}
 
 				// 'Sidebar images' mode - Doesn't load the button from each platform's social plugin library but instead displays images saying "Share"
-				if ( $wgShareUseBasicButtons && !$wgShareUsePlainLinks ) {
-					if ( $wgShareEmail ) {
+				if ( $shareUseBasicButtons && !$shareUsePlainLinks ) {
+					if ( $shareEmail ) {
 						$sidebar['share-header'][] = [
-							'html' => '<a href="mailto:%20?body=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/email.png" alt="'.wfMessage( 'share-email' )->plain().'" width="90" height="30"></a>',
+							'html' => '<a href="mailto:%20?body=' . urlencode( $currenturl ).'"><img src="'.$extensionAssetsPath.'/Share/resources/images/email.png" alt="'.wfMessage( 'share-email' )->plain().'" width="90" height="30"></a>',
 						];
 					}
 
-					if ( $wgShareFacebook ) {
+					if ( $shareFacebook ) {
 						$sidebar['share-header'][] = [
-							'html' => '<a href="https://www.facebook.com/sharer/sharer.php?u=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/facebook.png" alt="'.wfMessage( 'share-facebook' )->plain().'" width="90" height="30"></a>',
+							'html' => '<a href="https://www.facebook.com/sharer/sharer.php?u=' . urlencode( $currenturl ).'"><img src="'.$extensionAssetsPath.'/Share/resources/images/facebook.png" alt="'.wfMessage( 'share-facebook' )->plain().'" width="90" height="30"></a>',
 						];
 					}
 
-					if ( $wgShareLinkedIn ) {
+					if ( $shareLinkedIn ) {
 						$sidebar['share-header'][] = [
-							'html' => '<a href="https://www.linkedin.com/sharing/share-offsite/?url=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/linkedin.png" alt="'.wfMessage( 'share-linkedin' )->plain().'" width="90" height="30"></a>',
+							'html' => '<a href="https://www.linkedin.com/sharing/share-offsite/?url=' . urlencode( $currenturl ).'"><img src="'.$extensionAssetsPath.'/Share/resources/images/linkedin.png" alt="'.wfMessage( 'share-linkedin' )->plain().'" width="90" height="30"></a>',
 						];
 					}
 
-					if ( $wgShareReddit ) {
+					if ( $shareReddit ) {
 						$sidebar['share-header'][] = [
-							'html' => '<a href="https://www.reddit.com/submit?url=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/reddit.png" alt="'.wfMessage( 'share-reddit' )->plain().'" width="90" height="30"></a>',
+							'html' => '<a href="https://www.reddit.com/submit?url=' . urlencode( $currenturl ).'"><img src="'.$extensionAssetsPath.'/Share/resources/images/reddit.png" alt="'.wfMessage( 'share-reddit' )->plain().'" width="90" height="30"></a>',
 						];
 					}
 
-					if ( $wgShareTumblr ) {
+					if ( $shareTumblr ) {
 						$sidebar['share-header'][] = [
-							'html' => '<a href="https://www.tumblr.com/share/link?url=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/tumblr.png" alt="'.wfMessage( 'share-tumblr' )->plain().'" width="90" height="30"></a>',
+							'html' => '<a href="https://www.tumblr.com/share/link?url=' . urlencode( $currenturl ).'"><img src="'.$extensionAssetsPath.'/Share/resources/images/tumblr.png" alt="'.wfMessage( 'share-tumblr' )->plain().'" width="90" height="30"></a>',
 						];
 					}
 
-					if ( $wgShareTwitter ) {
+					if ( $shareTwitter ) {
 						$sidebar['share-header'][] = [
-							'html' => '<a href="https://www.twitter.com/share?url=' . urlencode( $currenturl ).'"><img src="'.$wgExtensionAssetsPath.'/Share/resources/images/twitter.png" alt="'.wfMessage( 'share-twitter' )->plain().'" width="90" height="30"></a>',
+							'html' => '<a href="https://www.twitter.com/share?url=' . urlencode( $currenturl ).'"><img src="'.$extensionAssetsPath.'/Share/resources/images/twitter.png" alt="'.wfMessage( 'share-twitter' )->plain().'" width="90" height="30"></a>',
 						];
 					}
 				}
 
 				// 'Plain Sidebar Links' mode - Displays all "Share" buttons as plain sidebar links as if they were any other link in the sidebar
-				if ( !$wgShareUseBasicButtons && $wgShareUsePlainLinks ) {
-					if ( $wgShareFacebook ) {
+				if ( !$shareUseBasicButtons && $shareUsePlainLinks ) {
+					if ( $shareFacebook ) {
 						$sidebar['share-header'][] = [
 							'text' => wfMessage( 'share-facebook' )->plain(),
 							'href' => 'https://www.facebook.com/sharer/sharer.php?u=' . urlencode( $currenturl ),
@@ -105,7 +112,7 @@ class ShareHooks {
 						];
 					}
 
-					if ( $wgShareTwitter ) {
+					if ( $shareTwitter ) {
 						$sidebar['share-header'][] = [
 							'text' => wfMessage( 'share-twitter' )->plain(),
 							'href' => 'https://www.twitter.com/share?url=' . urlencode( $currenturl ),
@@ -114,7 +121,7 @@ class ShareHooks {
 						];
 					}
 
-					if ( $wgShareEmail ) {
+					if ( $shareEmail ) {
 						$sidebar['share-header'][] = [
 							'text' => wfMessage( 'share-email' )->plain(),
 							'href' => 'mailto:%20?body=' . urlencode( $currenturl ),
@@ -123,7 +130,7 @@ class ShareHooks {
 						];
 					}
 
-					if ( $wgShareLinkedIn ) {
+					if ( $shareLinkedIn ) {
 						$sidebar['share-header'][] = [
 							'text' => wfMessage( 'share-linkedin' )->plain(),
 							'href' => 'https://www.linkedin.com/sharing/share-offsite/?url=' . urlencode( $currenturl ),
@@ -132,7 +139,7 @@ class ShareHooks {
 						];
 					}
 
-					if ( $wgShareReddit ) {
+					if ( $shareReddit ) {
 						$sidebar['share-header'][] = [
 							'text' => wfMessage( 'share-reddit' )->plain(),
 							'href' => 'https://www.reddit.com/submit?url=' . urlencode( $currenturl ),
@@ -141,7 +148,7 @@ class ShareHooks {
 						];
 					}
 
-					if ( $wgShareTumblr ) {
+					if ( $shareTumblr ) {
 						$sidebar['share-header'][] = [
 							'text' => wfMessage( 'share-tumblr' )->plain(),
 							'href' => 'https://www.tumblr.com/share/link?url=' . urlencode( $currenturl ),


### PR DESCRIPTION
This is the way recommended by https://www.mediawiki.org/wiki/Manual:Configuration_for_developers#For_extensions.